### PR TITLE
Add P-Token account and mint layouts

### DIFF
--- a/app/components/OffsetDisplay.tsx
+++ b/app/components/OffsetDisplay.tsx
@@ -1,4 +1,4 @@
-import { Offset, OffsetDisplayProps, INSTRUCTION_DATA_TYPES, SPL_MINT_FIELDS, SPL_TOKEN_FIELDS, TOKEN2022_MINT_FIELDS, SYSVAR_CLOCK_FIELDS, SYSVAR_RENT_FIELDS } from "../types";
+import { Offset, OffsetDisplayProps, INSTRUCTION_DATA_TYPES, P_TOKEN_ACCOUNT_FIELDS, P_TOKEN_MINT_FIELDS, SPL_MINT_FIELDS, SPL_TOKEN_FIELDS, TOKEN2022_MINT_FIELDS, SYSVAR_CLOCK_FIELDS, SYSVAR_RENT_FIELDS } from "../types";
 
 const OffsetDisplay = ({ accounts, instructionData, language }: OffsetDisplayProps) => {
   const calculateOffsets = () => {
@@ -45,6 +45,8 @@ const OffsetDisplay = ({ accounts, instructionData, language }: OffsetDisplayPro
 
       // Only show DATA offset for certain account types
       const shouldShowDataOffset = !(
+        account.type === "P-Token Mint" ||
+        account.type === "P-Token Account" ||
         account.type === "SPL Mint" ||
         account.type === "SPL Token" ||
         account.type === "Sysvar Clock" ||
@@ -59,6 +61,26 @@ const OffsetDisplay = ({ accounts, instructionData, language }: OffsetDisplayPro
       // Add individual field offsets for mint accounts
       if (account.type === "SPL Mint") {
         SPL_MINT_FIELDS.forEach((field) => {
+          const fieldSize = INSTRUCTION_DATA_TYPES[field.type];
+          offsets.push({
+            name: `${name}_${field.name.toUpperCase()}`,
+            offset: "0x" + (dataStartOffset + field.offset).toString(16).padStart(4, "0"),
+            comment: `${field.type} (${fieldSize} bytes)`,
+          });
+        });
+        currentOffset += account.dataLength;
+      } else if (account.type === "P-Token Mint") {
+        P_TOKEN_MINT_FIELDS.forEach((field) => {
+          const fieldSize = INSTRUCTION_DATA_TYPES[field.type];
+          offsets.push({
+            name: `${name}_${field.name.toUpperCase()}`,
+            offset: "0x" + (dataStartOffset + field.offset).toString(16).padStart(4, "0"),
+            comment: `${field.type} (${fieldSize} bytes)`,
+          });
+        });
+        currentOffset += account.dataLength;
+      } else if (account.type === "P-Token Account") {
+        P_TOKEN_ACCOUNT_FIELDS.forEach((field) => {
           const fieldSize = INSTRUCTION_DATA_TYPES[field.type];
           offsets.push({
             name: `${name}_${field.name.toUpperCase()}`,

--- a/app/types.ts
+++ b/app/types.ts
@@ -37,6 +37,8 @@ export type InstructionDataField = {
 
 export const ACCOUNT_TYPES = {
   System: 0,
+  "P-Token Account": 165,
+  "P-Token Mint": 82,
   "SPL Token": 165,
   "SPL Mint": 82,
   "Token2022 Account": 165,
@@ -55,6 +57,30 @@ export const TOKEN2022_EXTENSIONS = {
 };
 
 export type Extension = keyof typeof TOKEN2022_EXTENSIONS;
+
+export const P_TOKEN_MINT_FIELDS = [
+  { name: "mint_authority_flag", type: "u32" as InstructionDataType, offset: 0 },
+  { name: "mint_authority", type: "Pubkey" as InstructionDataType, offset: 4 },
+  { name: "supply", type: "u64" as InstructionDataType, offset: 36 },
+  { name: "decimals", type: "u8" as InstructionDataType, offset: 44 },
+  { name: "is_initialized", type: "u8" as InstructionDataType, offset: 45 },
+  { name: "freeze_authority_flag", type: "u32" as InstructionDataType, offset: 46 },
+  { name: "freeze_authority", type: "Pubkey" as InstructionDataType, offset: 50 },
+] as const;
+
+export const P_TOKEN_ACCOUNT_FIELDS = [
+  { name: "mint", type: "Pubkey" as InstructionDataType, offset: 0 },
+  { name: "owner", type: "Pubkey" as InstructionDataType, offset: 32 },
+  { name: "amount", type: "u64" as InstructionDataType, offset: 64 },
+  { name: "delegate_flag", type: "u32" as InstructionDataType, offset: 72 },
+  { name: "delegate", type: "Pubkey" as InstructionDataType, offset: 76 },
+  { name: "state", type: "u8" as InstructionDataType, offset: 108 },
+  { name: "is_native", type: "u32" as InstructionDataType, offset: 109 },
+  { name: "native_amount", type: "u64" as InstructionDataType, offset: 113 },
+  { name: "delegated_amount", type: "u64" as InstructionDataType, offset: 121 },
+  { name: "close_authority_flag", type: "u32" as InstructionDataType, offset: 129 },
+  { name: "close_authority", type: "Pubkey" as InstructionDataType, offset: 133 },
+] as const;
 
 export const SPL_MINT_FIELDS = [
   { name: "mint_authority", type: "Pubkey" as InstructionDataType, offset: 0 },


### PR DESCRIPTION
Adds P-Token Account and P-Token Mint support to the offset generator.

### Included layouts:

P-Token Mint:
- mint_authority_flag: 0
- mint_authority: 4
- supply: 36
- decimals: 44
- is_initialized: 45
- freeze_authority_flag: 46
- freeze_authority: 50

P-Token Account:
- mint: 0
- owner: 32
- amount: 64
- delegate_flag: 72
- delegate: 76
- state: 108
- is_native: 109
- native_amount: 113
- delegated_amount: 121
- close_authority_flag: 129
- close_authority: 133